### PR TITLE
Fix typo on Grandmaster about page

### DIFF
--- a/Grandmaster/index.html
+++ b/Grandmaster/index.html
@@ -172,7 +172,7 @@
 						<section class="col-4 col-6-medium col-12-xsmall">
 							<div class="col-4 col-6-xsmall"><span class="image fit"><img src="images/Emma_Fox.jpg"
 										alt="Emma Fox" /></span></div>
-							<h3>Emma Fox <i>(she/her)</i></h3>
+							<h3>Emma Fox <i>(she/they)</i></h3>
 							<p>The truest opossum of the group, Emma fills the other ⅝ of a mechanical engineer’s shoes. They are
 								majoring
 								in Engineering: Sustainability and are always excited to do hands-on projects, learn new things, work


### PR DESCRIPTION
There was a small typo on the Grandmaster about page due to hasty copy-and-pasting. Sorry about that! This PR fixes it.